### PR TITLE
update model/group.rbのリファクタリング

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -17,11 +17,10 @@ class Group < ApplicationRecord
   end
 
   def get_members
-    members = ""
+    members = []
     users.each do |member|
-      members += member.nickname
-      members += " "
+      members << member.nickname
     end
-    return members
+    return members.join(", ")
   end
 end


### PR DESCRIPTION
# What
model/group.rb にて、グループメンバー一覧を渡す際の処理に、joinメソッドを用いるようにした

# Why
コードの可読性を上げるため